### PR TITLE
Manage real-time audio and video calls

### DIFF
--- a/src/components/chat/ChatHeader.tsx
+++ b/src/components/chat/ChatHeader.tsx
@@ -99,6 +99,7 @@ export default function ChatHeader({
     endCall,
     rejectCall,
     initLocalStream,
+    currentCallType,
   } = useCallSocket({ currentUserId });
 
 
@@ -232,6 +233,24 @@ export default function ChatHeader({
       setIsCallModalOpen(true);
     }
   }, [incomingCall, isInCall]);
+
+  // Update video and mic state when local stream changes
+  useEffect(() => {
+    if (localStream) {
+      const videoTracks = localStream.getVideoTracks();
+      const audioTracks = localStream.getAudioTracks();
+      
+      if (videoTracks.length > 0) {
+        setIsVideoOn(videoTracks[0].enabled);
+        console.log('🎥 Video track state updated:', videoTracks[0].enabled);
+      }
+      
+      if (audioTracks.length > 0) {
+        setIsMicOn(audioTracks[0].enabled);
+        console.log('🎤 Audio track state updated:', audioTracks[0].enabled);
+      }
+    }
+  }, [localStream]);
 
   const handleLeaveGroup = async () => {
     if (onLeaveGroup && confirm("Are you sure you want to leave this group?")) {
@@ -386,6 +405,7 @@ export default function ChatHeader({
         isSpeakerOn={isSpeakerOn}
         callerName={contact.name}
         callerAvatar={contact.profilePicture || contact.avatar}
+        callType={currentCallType}
       />
     </div>
   );

--- a/src/components/modals/CallModal.tsx
+++ b/src/components/modals/CallModal.tsx
@@ -45,6 +45,7 @@ interface CallModalProps {
   isSpeakerOn: boolean;
   callerName: string;
   callerAvatar?: string;
+  callType?: 'video' | 'audio';
 }
 
 export default function CallModal({
@@ -66,6 +67,7 @@ export default function CallModal({
   isSpeakerOn,
   callerName,
   callerAvatar,
+  callType,
 }: CallModalProps) {
   const localVideoRef = useRef<HTMLVideoElement>(null);
   const remoteVideoRef = useRef<HTMLVideoElement>(null);
@@ -74,14 +76,30 @@ export default function CallModal({
    useEffect(() => {
     if (localVideoRef.current && localStream) {
       localVideoRef.current.srcObject = localStream;
+      console.log('🎥 Local video element updated with stream:', localStream.id);
     }
   }, [localStream]);
 
   useEffect(() => {
     if (remoteVideoRef.current && remoteStream) {
       remoteVideoRef.current.srcObject = remoteStream;
+      console.log('📺 Remote video element updated with stream:', remoteStream.id);
     }
   }, [remoteStream]);
+
+  // Debug logging for call type
+  useEffect(() => {
+    console.log('📊 CallModal Debug:', {
+      callType,
+      incomingCallType: incomingCall?.type,
+      isIncoming,
+      isInCall,
+      hasLocalStream: !!localStream,
+      hasRemoteStream: !!remoteStream,
+      isVideoOn,
+      shouldShowVideo: (callType === 'video' || incomingCall?.type === 'video') && isVideoOn
+    });
+  }, [callType, incomingCall, isIncoming, isInCall, localStream, remoteStream, isVideoOn]);
 
   const handleAccept = () => {
     onAccept();
@@ -166,7 +184,7 @@ export default function CallModal({
           )}
 
           {/* Local Video (Picture-in-Picture) */}
-          {localStream && isVideoOn && (
+          {localStream && isVideoOn && (callType === 'video' || incomingCall?.type === 'video') && localStream.getVideoTracks().length > 0 && (
             <Box
               sx={{
                 position: 'absolute',
@@ -267,7 +285,7 @@ export default function CallModal({
               </IconButton>
 
               {/* Video Toggle (only for video calls) */}
-              {incomingCall?.type === 'video' && (
+              {(callType === 'video' || incomingCall?.type === 'video') && localStream && localStream.getVideoTracks().length > 0 && (
                 <IconButton
                   onClick={onToggleVideo}
                   sx={{


### PR DESCRIPTION
Persist video call functionality after acceptance by tracking call type and updating UI conditions.

Previously, video calls would revert to audio-only after the recipient accepted because the `incomingCall` state, which determined video features, was cleared. This PR introduces a `currentCallType` state to maintain the call's video status, ensuring video controls and streams remain active throughout the call.

---
<a href="https://cursor.com/background-agent?bcId=bc-1db11f0b-b452-48da-adfc-3d40bb17b0c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1db11f0b-b452-48da-adfc-3d40bb17b0c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

