### PR TITLE
Debug prerendering error in nextjs build

### DIFF
--- a/src/components/modals/CallModal.tsx
+++ b/src/components/modals/CallModal.tsx
@@ -59,8 +59,9 @@ export default function CallModal({
   callError,
   deviceStatus,
 }: CallModalProps) {
-   const isAndroid = /Android/i.test(navigator.userAgent);
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+  const userAgent = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  const isAndroid = /Android/i.test(userAgent);
+  const isIOS = /iPad|iPhone|iPod/.test(userAgent);
   const isMobile = isAndroid || isIOS;
   const localVideoRef = useRef<HTMLVideoElement>(null);
   const remoteVideoRef = useRef<HTMLVideoElement>(null);

--- a/src/hooks/useCallSocket.ts
+++ b/src/hooks/useCallSocket.ts
@@ -60,10 +60,13 @@ export const useCallSocket = ({ currentUserId }: UseCallSocketProps) => {
     callId?: string;
   }>({});
 
-  // Device and platform detection
-  const isAndroid = /Android/i.test(navigator.userAgent);
-  const isLegacyDevice = isAndroid && parseFloat(navigator.userAgent.match(/Android (\d+\.?\d*)/)?.[1] || '0') < 11;
-
+  // Device and platform detection (guarded for SSR)
+  const __ua = typeof navigator !== 'undefined' ? navigator.userAgent : '';
+  const isAndroid = /Android/i.test(__ua);
+  const androidVersionMatch = __ua.match(/Android (\d+\.?\d*)/);
+  const androidVersion = androidVersionMatch ? parseFloat(androidVersionMatch[1]) : 0;
+  const isLegacyDevice = isAndroid && androidVersion > 0 && androidVersion < 11;
+  
   // Initialize audio and check WebRTC support on mount
   useEffect(() => {
     const initializeCallSystem = async () => {


### PR DESCRIPTION
Add SSR guards for `navigator.userAgent` access to resolve 'window is not defined' build error.

The `ReferenceError: window is not defined` occurred because `navigator.userAgent` was being accessed at the module scope in `useCallSocket.ts` and `CallModal.tsx`. During Next.js's server-side rendering (SSR) or build process, browser-specific objects like `window` and `navigator` are not available, leading to the build failure. The guards ensure these properties are only accessed in a client-side environment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d328d86b-4a5f-481d-b594-6f740b569152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d328d86b-4a5f-481d-b594-6f740b569152">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

